### PR TITLE
Remove references to mpi-operator

### DIFF
--- a/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml
+++ b/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml
@@ -65,11 +65,6 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/mpi-job
-    name: mpi-job
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
         path: openshift/openshiftstack/application/kfserving
     name: kfserving
   - kustomizeConfig:
@@ -79,5 +74,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/lavlas/manifests/archive/v1.5-branch-openshift.tar.gz
+    uri: https://github.com/lavlas/manifests/archive/feature/kf-v1.5.tar.gz
   version: v1.5.0

--- a/openshift/openshiftstack/application/mpi-job/kustomization.yaml
+++ b/openshift/openshiftstack/application/mpi-job/kustomization.yaml
@@ -1,6 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-namespace: kubeflow
-resources:
-- ../../../../apps/mpi-job/upstream/overlays/kubeflow
-


### PR DESCRIPTION
This commit removes all references to `MPIJob` resources, since it is managed by the
training operator from KF 1.5