### PR TITLE
Fix errors in kfp-tekton

### DIFF
--- a/openshift/openshiftstack/application/kfp-tekton/daemonset.yaml
+++ b/openshift/openshiftstack/application/kfp-tekton/daemonset.yaml
@@ -1,0 +1,39 @@
+# Source: dlf-chart/charts/csi-s3-chart/templates/csi-s3.yaml
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: kfp-csi-s3
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      serviceAccountName: kfp-csi-s3
+      containers:
+        - name: driver-registrar
+          args:
+            - --v=5
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/kfp-csi-s3/csi.sock
+        - name: kfp-csi-s3
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+            - mountPath: /var/lib/kubelet/pods
+              mountPropagation: Bidirectional
+              name: mountpoint-dir
+            - mountPath: /dev
+              name: dev-dir
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+          name: mountpoint-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: Directory
+          name: registration-dir
+

--- a/openshift/openshiftstack/application/kfp-tekton/kustomization.yaml
+++ b/openshift/openshiftstack/application/kfp-tekton/kustomization.yaml
@@ -6,3 +6,6 @@ resources:
 
 patchesStrategicMerge:
 - removesidemenu.yaml
+- daemonset.yaml
+- statefulset_attacher.yaml
+- statefulset_provisioner.yaml

--- a/openshift/openshiftstack/application/kfp-tekton/statefulset_attacher.yaml
+++ b/openshift/openshiftstack/application/kfp-tekton/statefulset_attacher.yaml
@@ -1,0 +1,16 @@
+---
+# Source: dlf-chart/charts/csi-s3-chart/templates/attacher.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-attacher-s3
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+---

--- a/openshift/openshiftstack/application/kfp-tekton/statefulset_provisioner.yaml
+++ b/openshift/openshiftstack/application/kfp-tekton/statefulset_provisioner.yaml
@@ -1,0 +1,16 @@
+
+# Source: dlf-chart/charts/csi-s3-chart/templates/provisioner.yaml
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: csi-provisioner-s3
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/plugins/kfp-csi-s3
+            type: DirectoryOrCreate
+          name: socket-dir
+---


### PR DESCRIPTION
This commit updates the kubelet path in kfp-csi-s3 pods to make it compatible on OpenShift

This change would be reverted in KF 1.6, as we can set `kubelet_path` parameter from later versions of kfp-tekton https://github.com/opendatahub-io/manifests/issues/90#issuecomment-1115385930 